### PR TITLE
Changed ifdefs for NSTask headers to supress the warning in iOS projects

### DIFF
--- a/Sources/NSTask+AnyPromise.h
+++ b/Sources/NSTask+AnyPromise.h
@@ -1,3 +1,5 @@
+#if TARGET_OS_MAC && !TARGET_OS_EMBEDDED && !TARGET_OS_SIMULATOR
+
 #import <Foundation/NSTask.h>
 #import <PromiseKit/AnyPromise.h>
 
@@ -47,3 +49,5 @@
 - (AnyPromise *)promise NS_REFINED_FOR_SWIFT;
 
 @end
+
+#endif

--- a/Sources/PMKFoundation.h
+++ b/Sources/PMKFoundation.h
@@ -1,6 +1,3 @@
 #import "NSNotificationCenter+AnyPromise.h"
 #import "NSURLSession+AnyPromise.h"
-
-#if TARGET_OS_MAC && !TARGET_OS_EMBEDDED && !TARGET_OS_SIMULATOR
-    #import "NSTask+AnyPromise.h"
-#endif
+#import "NSTask+AnyPromise.h"


### PR DESCRIPTION
Without this fix I'm getting the following error in our iOS-only project:
```
<module-includes>:1:1: Umbrella header for module 'PMKFoundation' does not include header 'NSTask+AnyPromise.h'
```