### PR TITLE
Fix cycle in NSNotificationCenter

### DIFF
--- a/Sources/NSNotificationCenter+AnyPromise.m
+++ b/Sources/NSNotificationCenter+AnyPromise.m
@@ -6,8 +6,10 @@
 
 + (AnyPromise *)once:(NSString *)name {
     return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
-        __block id identifier = [[NSNotificationCenter defaultCenter] addObserverForName:name object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+        __block id identifier;
+        identifier = [[NSNotificationCenter defaultCenter] addObserverForName:name object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
             [[NSNotificationCenter defaultCenter] removeObserver:identifier name:name object:nil];
+            identifier = nil;
             resolve(PMKManifold(note, note.userInfo));
         }];
     }];


### PR DESCRIPTION
I'm guessing this is what infer is concerned about in https://github.com/mxcl/PromiseKit/issues/740.

More context in https://stackoverflow.com/questions/8477629/why-doesnt-remove-observer-from-nsnotificationcenteraddobserverfornameusingbl - I haven't had a chance to hit this in Instruments to confirm yet.