### PR TITLE
Remove deprecated usage of -[NSTask launch] on supported OS versions

### DIFF
--- a/Sources/NSTask+AnyPromise.m
+++ b/Sources/NSTask+AnyPromise.m
@@ -37,7 +37,16 @@
                 resolve([NSError errorWithDomain:PMKErrorDomain code:PMKTaskError userInfo:info]);
             }
         };
-        [self launch];
+        
+        if (@available(macOS 10.13, *)) {
+            NSError *error = nil;
+            
+            if (![self launchAndReturnError:&error]) {
+                resolve(error);
+            }
+        } else {
+            [self launch];
+        }
     }];
 }
 


### PR DESCRIPTION
On macOS 10.13, the -[NSTask launch] method has been deprecated and replaced by a newer method, -launchAndReturnError:. The newer method solves a serious problem with NSTask in that if the executable cannot be launched at runtime, which can easily happen if the executable bit is not set in the permissions mode, -launch will throw an exception. Since Swift code cannot natively handle exceptions, this is likely to crash the entire app. By contrast, the -launchAndReturnError: method simply returns an error describing what went wrong, so that the program can decide how to proceed. This seems much more in line with PromiseKit's mission as a project.

This commit request is a simple one; it checks if the user is running macOS 10.13 or greater, and if so, it uses -launchAndReturnError: instead of -launch. If an error is returned, it is passed to the resolver so that it will be handled by the next `catch` block in the promise chain.

I hope you've found this useful.