### PR TITLE
Fix build error on Linux

### DIFF
--- a/Sources/NSURLSession+Promise.swift
+++ b/Sources/NSURLSession+Promise.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if os(Linux)
+import FoundationNetworking
+#endif
 #if !PMKCocoaPods
 import PromiseKit
 #endif


### PR DESCRIPTION
Fixes the following build error on Linux with Swift 5.1:

```
[82/104] Compiling PMKFoundation NSURLSession+Promise.swift
/package/.build/checkouts/Foundation/Sources/NSURLSession+Promise.swift:21:11: error: 'URLSession' is unavailable: This type has moved to the FoundationNetworking module. Import that module to use it.
extension URLSession {
          ^~~~~~~~~~
Foundation.URLSession:2:18: note: 'URLSession' has been explicitly marked unavailable here
public typealias URLSession = AnyObject
                 ^
```